### PR TITLE
Separating python packaging from the unit testing 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,20 +160,9 @@ export MAVEN_OPTS="-Xmx512m -XX:PermSize=256m"
                 <module>scoring-engine</module>
                 <module>scoring-models</module>
                 <module>rest-server</module>
+                <module>python-client</module>
                 <module>deploy</module>
                 <module>package</module>
-            </modules>
-        </profile>
-
-        <profile>
-            <id>python-unittests</id>
-            <activation>
-                <property>
-                    <name>!skipTests</name>
-                </property>
-            </activation>
-            <modules>
-                <module>python-client</module>
             </modules>
         </profile>
 

--- a/python-client/pom.xml
+++ b/python-client/pom.xml
@@ -18,42 +18,62 @@
         <version>master-SNAPSHOT</version>
     </parent>
 
+    <profiles>
+        <profile>
+            <id>python-unittests</id>
+            <activation>
+                <property>
+                    <name>!skipTests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>chmod-shellscripts</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>chmod</executable>
+                                    <workingDirectory>${basedir}</workingDirectory>
+                                    <arguments>
+                                        <argument>+x</argument>
+                                        <argument>trustedanalytics/tests/exec_all.sh</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>python-tests</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>bash</executable>
+                                    <workingDirectory>${basedir}</workingDirectory>
+                                    <arguments>
+                                        <argument>trustedanalytics/tests/exec_all.sh</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-
                 <executions>
-                    <execution>
-                        <id>chmod-shellscripts</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>chmod</executable>
-                            <workingDirectory>${basedir}</workingDirectory>
-                            <arguments>
-                                <argument>+x</argument>
-                                <argument>trustedanalytics/tests/exec_all.sh</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>python-tests</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <configuration>
-                            <executable>bash</executable>
-                            <workingDirectory>${basedir}</workingDirectory>
-                            <arguments>
-                                <argument>trustedanalytics/tests/exec_all.sh</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>package-python-yarn-client</id>
                         <phase>package</phase>


### PR DESCRIPTION
(many devs use skipTests but then want to run integration-tests and still need packaging to have been done)
