### PR TITLE
Reducing amount of data passed in LDA join

### DIFF
--- a/engine-plugins/model-plugins/src/main/scala/org/apache/spark/mllib/clustering/AtkLdaModel.scala
+++ b/engine-plugins/model-plugins/src/main/scala/org/apache/spark/mllib/clustering/AtkLdaModel.scala
@@ -168,8 +168,10 @@ case class AtkLdaModel(numTopics: Int) {
                        outputDocumentColumnName: String,
                        outputTopicVectorColumnName: String): Unit = {
     val topicDist = distLdaModel.topicDistributions
-    val topicsGivenDocs: RDD[Row] = corpus.join(topicDist).map {
-      case (documentId, ((document, wordVector), topicVector)) =>
+    val topicsGivenDocs: RDD[Row] = corpus.map{case (documentId, (document, wordVector)) =>
+      (documentId, document) //reducing size of corpus due to shuffle failures in Spark 1.3.0
+    }.join(topicDist).map {
+      case (documentId, (document, topicVector)) =>
         new GenericRow(Array[Any](document, topicVector.toArray.toVector))
     }
 


### PR DESCRIPTION
Fixing executor lost errors during join in Spark 1.3
