### PR TITLE
Fix: Adding duplicate Vertices was breaking Edge Frame

### DIFF
--- a/engine/engine-core/src/main/scala/org/apache/spark/atk/graph/VertexFrameRdd.scala
+++ b/engine/engine-core/src/main/scala/org/apache/spark/atk/graph/VertexFrameRdd.scala
@@ -146,26 +146,25 @@ class VertexFrameRdd(schema: VertexSchema, prev: RDD[Row]) extends FrameRdd(sche
       case ((row1: Row, vid1Preferred: Boolean, row1Preferred: Boolean), (row2: Row, vid2Preferred: Boolean, row2Preferred: Boolean)) =>
         if (row1Preferred) {
           // prefer newer data
-          if (vid1Preferred) {
-            (row1, false, false)
-          }
-          else {
+          if (vid2Preferred) {
             // here we are keeping old vids but updating all other fields
             val values = row1.toSeq.toArray
             values(vidIndex) = row2.get(vidIndex)
             (new GenericRow(values), false, false)
           }
-
+          else {
+            (row1, false, false)
+          }
         }
         else {
-          if (vid2Preferred) {
-            (row2, false, false)
-          }
-          else {
+          if (vid1Preferred) {
             // here we are keeping old vids but updating all other fields
             val values = row2.toSeq.toArray
             values(vidIndex) = row1.get(vidIndex)
             (new GenericRow(values), false, false)
+          }
+          else {
+            (row2, false, false)
           }
         }
     }.values.map { case (row: Row, vidPreferred: Boolean, rowNew: Boolean) => row }

--- a/python-client/trustedanalytics/core/frame.py
+++ b/python-client/trustedanalytics/core/frame.py
@@ -1572,8 +1572,7 @@ A VertexFrame is similar to a Frame but with a few important differences:
             >>> my_graph = ta.Graph()
             >>> my_graph.define_vertex_type('users')
             >>> my_vertex_frame = my_graph.vertices['users']
-            >>> my_vertex_frame.add_vertices(my_frame, 'user_id',
-            ... ['user_name', 'age'])
+            >>> my_vertex_frame.add_vertices(my_frame, 'user_id', ['user_name', 'age'])
 
     Retrieve a previously defined graph and retrieve a VertexFrame from it:
 
@@ -1670,9 +1669,9 @@ A VertexFrame is similar to a Frame but with a few important differences:
             >>> graph.vertices['viewer'].inspect()
             [#]  _vid  _label  viewer   profile
             ===================================
-            [0]     1  viewer  fred           0
+            [0]     4  viewer  fred           0
             [1]     8  viewer  pebbles        1
-            [2]     5  viewer  wilma          0
+            [2]     7  viewer  wilma          0
 
             >>> graph.vertices['film'].add_vertices(frame, 'movie')
             <progress>
@@ -1681,7 +1680,7 @@ A VertexFrame is similar to a Frame but with a few important differences:
             [#]  _vid  _label  movie
             ===================================
             [0]    19  film    Land Before Time
-            [1]    14  film    Ice Age
+            [1]    20  film    Ice Age
             [2]    12  film    Jurassic Park
             [3]    11  film    Croods
             [4]    13  film    2001
@@ -1692,14 +1691,14 @@ A VertexFrame is similar to a Frame but with a few important differences:
             >>> graph.edges['rating'].inspect()
             [#]  _eid  _src_vid  _dest_vid  _label  rating
             ==============================================
-            [0]    24         1         14  rating       4
-            [1]    22         1         12  rating       5
-            [2]    21         1         11  rating       5
-            [3]    23         1         13  rating       2
+            [0]    24         4         20  rating       4
+            [1]    22         4         12  rating       5
+            [2]    21         4         11  rating       5
+            [3]    23         4         13  rating       2
             [4]    29         8         19  rating       3
-            [5]    30         8         14  rating       5
+            [5]    30         8         20  rating       5
             [6]    28         8         11  rating       4
-            [7]    27         5         14  rating       4
+            [7]    27         5         20  rating       4
             [8]    25         5         12  rating       3
             [9]    26         5         13  rating       5
 
@@ -1715,20 +1714,20 @@ A VertexFrame is similar to a Frame but with a few important differences:
             [#]  _vid  _label  movie
             ===================================
             [0]    19  film    Land Before Time
-            [1]    14  film    Ice Age
+            [1]    20  film    Ice Age
             [2]    12  film    Jurassic Park
             [3]    13  film    2001
 
             >>> graph.edges['rating'].inspect()
             [#]  _eid  _src_vid  _dest_vid  _label  rating
             ==============================================
-            [0]    22         1         12  rating       5
-            [1]    25         5         12  rating       3
-            [2]    23         1         13  rating       2
-            [3]    26         5         13  rating       5
-            [4]    24         1         14  rating       4
-            [5]    30         8         14  rating       5
-            [6]    27         5         14  rating       4
+            [0]    24         4         20  rating       4
+            [1]    30         8         20  rating       5
+            [2]    27         7         20  rating       4
+            [3]    22         4         12  rating       5
+            [4]    25         7         12  rating       3
+            [5]    23         4         13  rating       2
+            [6]    26         7         13  rating       5
             [7]    29         8         19  rating       3
 
         """

--- a/python-client/trustedanalytics/core/frame.py
+++ b/python-client/trustedanalytics/core/frame.py
@@ -1689,18 +1689,18 @@ A VertexFrame is similar to a Frame but with a few important differences:
             <progress>
 
             >>> graph.edges['rating'].inspect()
-            [#]  _eid  _src_vid  _dest_vid  _label  rating
-            ==============================================
-            [0]    24         4         20  rating       4
-            [1]    22         4         12  rating       5
-            [2]    21         4         11  rating       5
-            [3]    23         4         13  rating       2
-            [4]    29         8         19  rating       3
-            [5]    30         8         20  rating       5
-            [6]    28         8         11  rating       4
-            [7]    27         5         20  rating       4
-            [8]    25         5         12  rating       3
-            [9]    26         5         13  rating       5
+                [#]  _eid  _src_vid  _dest_vid  _label  rating
+                ==============================================
+                [0]    24         4         20  rating       4
+                [1]    22         4         12  rating       5
+                [2]    21         4         11  rating       5
+                [3]    23         4         13  rating       2
+                [4]    29         8         19  rating       3
+                [5]    30         8         20  rating       5
+                [6]    28         8         11  rating       4
+                [7]    27         7         20  rating       4
+                [8]    25         7         12  rating       3
+                [9]    26         7         13  rating       5
 
         Call drop_rows() on the film VertexFrame to remove the row for the movie 'Croods' (vid = 11).
         Dangling edges (edges corresponding to 'Croods, vid = 11) are also removed.

--- a/python-client/trustedanalytics/core/graph.py
+++ b/python-client/trustedanalytics/core/graph.py
@@ -311,7 +311,6 @@ Default is None.""")
     >>> graph.edges['rating'].add_edges(frame2, 'viewer', 'movie', ['rating'])
     <progress>
 
-    <skip>  # todo: fix bug DPAT-926
     >>> graph.edges['rating'].inspect(20)
     [##]  _eid  _src_vid  _dest_vid  _label  rating
     ===============================================
@@ -336,7 +335,6 @@ Default is None.""")
     [18]    56        35         42  rating       5
     [19]    55        35         41  rating       5
 
-    </skip>
     >>> graph.edge_count
     <progress>
     20

--- a/python-client/trustedanalytics/core/graph.py
+++ b/python-client/trustedanalytics/core/graph.py
@@ -210,9 +210,9 @@ Default is None.""")
     >>> graph.vertices['viewer'].inspect()
     [#]  _vid  _label  viewer   profile
     ===================================
-    [0]     1  viewer  fred           0
+    [0]     4  viewer  fred           0
     [1]     8  viewer  pebbles        1
-    [2]     5  viewer  wilma          0
+    [2]     7  viewer  wilma          0
 
     >>> graph.vertices['film'].add_vertices(frame, 'movie')
     <progress>
@@ -220,7 +220,7 @@ Default is None.""")
     [#]  _vid  _label  movie
     ===================================
     [0]    19  film    Land Before Time
-    [1]    14  film    Ice Age
+    [1]    20  film    Ice Age
     [2]    12  film    Jurassic Park
     [3]    11  film    Croods
     [4]    13  film    2001
@@ -230,16 +230,16 @@ Default is None.""")
     >>> graph.edges['rating'].inspect()
     [#]  _eid  _src_vid  _dest_vid  _label  rating
     ==============================================
-    [0]    24         1         14  rating       4
-    [1]    22         1         12  rating       5
-    [2]    21         1         11  rating       5
-    [3]    23         1         13  rating       2
+    [0]    24         4         20  rating       4
+    [1]    22         4         12  rating       5
+    [2]    21         4         11  rating       5
+    [3]    23         4         13  rating       2
     [4]    29         8         19  rating       3
-    [5]    30         8         14  rating       5
+    [5]    30         8         20  rating       5
     [6]    28         8         11  rating       4
-    [7]    27         5         14  rating       4
-    [8]    25         5         12  rating       3
-    [9]    26         5         13  rating       5
+    [7]    27         7         20  rating       4
+    [8]    25         7         12  rating       3
+    [9]    26         7         13  rating       5
 
     Explore basic graph properties:
 
@@ -286,10 +286,10 @@ Default is None.""")
     >>> graph.vertices['viewer'].inspect()
     [#]  _vid  _label  viewer     profile
     =====================================
-    [0]     5  viewer  wilma            0
-    [1]     1  viewer  fred             0
-    [2]    31  viewer  betty            0
-    [3]    35  viewer  barney           0
+    [0]     7  viewer  wilma            0
+    [1]     4  viewer  fred             0
+    [2]    34  viewer  betty            0
+    [3]    38  viewer  barney           0
     [4]     8  viewer  pebbles          1
     [5]    39  viewer  bamm bamm        1
 
@@ -299,10 +299,10 @@ Default is None.""")
     [#]  _vid  _label  movie
     ===================================
     [0]    13  film    2001
-    [1]    44  film    Ice Age
-    [2]    41  film    Croods
-    [3]    43  film    Land Before Time
-    [4]    42  film    Jurassic Park
+    [1]    48  film    Ice Age
+    [2]    49  film    Croods
+    [3]    50  film    Land Before Time
+    [4]    46  film    Jurassic Park
 
     >>> graph.vertex_count
     <progress>
@@ -314,26 +314,26 @@ Default is None.""")
     >>> graph.edges['rating'].inspect(20)
     [##]  _eid  _src_vid  _dest_vid  _label  rating
     ===============================================
-    [0]     24         1         14  rating       4
-    [1]     22         1         12  rating       5
-    [2]     21         1         11  rating       5
-    [3]     23         1         13  rating       2
+    [0]     24         4         20  rating       4
+    [1]     22         4         12  rating       5
+    [2]     21         4         11  rating       5
+    [3]     23         4         13  rating       2
     [4]     29         8         19  rating       3
-    [5]     30         8         14  rating       5
+    [5]     30         8         20  rating       5
     [6]     28         8         11  rating       4
-    [7]     27         5         14  rating       4
-    [8]     25         5         12  rating       3
-    [9]     26         5         13  rating       5
-    [10]    60        39         43  rating       3
-    [11]    59        39         41  rating       5
-    [12]    53        31         43  rating       4
-    [13]    54        31         44  rating       3
-    [14]    52        31         42  rating       3
-    [15]    51        31         41  rating       5
-    [16]    57        35         43  rating       3
-    [17]    58        35         44  rating       5
-    [18]    56        35         42  rating       5
-    [19]    55        35         41  rating       5
+    [7]     27         7         20  rating       4
+    [8]     25         7         12  rating       3
+    [9]     26         7         13  rating       5
+    [10]    60        39         50  rating       3
+    [11]    59        39         49  rating       5
+    [12]    53        34         50  rating       4
+    [13]    54        34         48  rating       3
+    [14]    52        34         46  rating       3
+    [15]    51        34         49  rating       5
+    [16]    57        38         50  rating       3
+    [17]    58        38         48  rating       5
+    [18]    56        38         46  rating       5
+    [19]    55        38         49  rating       5
 
     >>> graph.edge_count
     <progress>
@@ -377,8 +377,8 @@ Default is None.""")
     >>> graph2.vertices['viewer'].inspect()
     [#]  _vid  _label  person     profile
     =====================================
-    [0]    31  viewer  betty            0
-    [1]    35  viewer  barney           0
+    [0]    34  viewer  betty            0
+    [1]    38  viewer  barney           0
     [2]    39  viewer  bamm bamm        1
 
     >>> graph2.vertices['viewer'].drop_duplicates("profile")
@@ -392,7 +392,7 @@ Default is None.""")
     >>> graph2.vertices['viewer'].inspect()
     [#]  _vid  _label  person     profile
     =====================================
-    [0]    31  viewer  betty            0
+    [0]    34  viewer  betty            0
     [1]    39  viewer  bamm bamm        1
 
     Now check our edges to see that they have also be filtered.
@@ -400,12 +400,12 @@ Default is None.""")
     >>> graph2.edges['rating'].inspect()
     [#]  _eid  _src_vid  _dest_vid  _label  score
     =============================================
-    [0]    60        39         43  rating      3
-    [1]    59        39         41  rating      5
-    [2]    53        31         43  rating      4
-    [3]    54        31         44  rating      3
-    [4]    52        31         42  rating      3
-    [5]    51        31         41  rating      5
+    [0]    60        39         50  rating      3
+    [1]    59        39         49  rating      5
+    [2]    53        34         50  rating      4
+    [3]    54        34         48  rating      3
+    [4]    52        34         46  rating      3
+    [5]    51        34         49  rating      5
 
     Only source vertices 31 and 39 remain.
 
@@ -415,10 +415,10 @@ Default is None.""")
     [#]  _vid  _label  movie
     ===================================
     [0]    13  film    2001
-    [1]    44  film    Ice Age
-    [2]    41  film    Croods
-    [3]    43  film    Land Before Time
-    [4]    42  film    Jurassic Park
+    [1]    48  film    Ice Age
+    [2]    49  film    Croods
+    [3]    50  film    Land Before Time
+    [4]    46  film    Jurassic Park
 
     >>> graph2.vertices['film'].drop_rows(lambda row: row.movie=='Croods')
     <progress>
@@ -427,19 +427,19 @@ Default is None.""")
     [#]  _vid  _label  movie
     ===================================
     [0]    13  film    2001
-    [1]    44  film    Ice Age
-    [2]    43  film    Land Before Time
-    [3]    42  film    Jurassic Park
+    [1]    48  film    Ice Age
+    [2]    50  film    Land Before Time
+    [3]    46  film    Jurassic Park
 
     Dangling edges (edges that correspond to the movie 'Croods', vid 41) were also removed:
 
     >>> graph2.edges['rating'].inspect()
     [#]  _eid  _src_vid  _dest_vid  _label  score
     =============================================
-    [0]    54        31         44  rating      3
-    [1]    52        31         42  rating      3
-    [2]    60        39         43  rating      3
-    [3]    53        31         43  rating      4
+    [0]    54        34         48  rating      3
+    [1]    52        34         46  rating      3
+    [2]    60        39         50  rating      3
+    [3]    53        34         50  rating      4
 
 
         """


### PR DESCRIPTION
Fixing bug where when adding duplicate vertices the new data was "preferred" but that meant vid's were being updating and so edges were broken
