### PR TITLE
api logger can read command def

### DIFF
--- a/python-client/trustedanalytics/meta/metaprog.py
+++ b/python-client/trustedanalytics/meta/metaprog.py
@@ -526,14 +526,13 @@ def _compile_function(func_name, func_text, dependencies):
 def create_function(loadable_class, command_def, execute_command_function=None):
     """Creates the function which will appropriately call execute_command for this command"""
     execute_command = create_execute_command_function(command_def, execute_command_function)
-    api_decorator = get_api_context_decorator(logging.getLogger(loadable_class.__module__))
     if command_def.is_constructor:
-        func_text = get_function_text(command_def, body_text=_get_init_body_text(command_def), decorator_text='@api')
-        #print "func_text for %s = %s" % (command_def.full_name, func_text)
-        dependencies = {'api': api_decorator, 'base_class': _installable_classes_store.get(entity_type_to_baseclass_name(command_def.install_path.full), CommandInstallable), EXECUTE_COMMAND_FUNCTION_NAME: execute_command}
+        func_text = get_function_text(command_def, body_text=_get_init_body_text(command_def))
+        # print "func_text for %s = %s" % (command_def.full_name, func_text)
+        dependencies = {'base_class': _installable_classes_store.get(entity_type_to_baseclass_name(command_def.install_path.full), CommandInstallable), EXECUTE_COMMAND_FUNCTION_NAME: execute_command}
     else:
-        func_text = get_function_text(command_def, body_text='return ' + get_call_execute_command_text(command_def), decorator_text='@api')
-        dependencies = {'api': api_decorator,  EXECUTE_COMMAND_FUNCTION_NAME: execute_command}
+        func_text = get_function_text(command_def, body_text='return ' + get_call_execute_command_text(command_def))
+        dependencies = {EXECUTE_COMMAND_FUNCTION_NAME: execute_command}
     try:
         function = _compile_function(command_def.name, func_text, dependencies)
     except:
@@ -542,4 +541,6 @@ def create_function(loadable_class, command_def, execute_command_function=None):
         raise
     function.command = command_def
     function.__doc__ = get_spa_docstring(command_def)
-    return function
+
+    api_decorator = get_api_context_decorator(logging.getLogger(loadable_class.__module__))
+    return api_decorator(function)


### PR DESCRIPTION
small mod to metaprog such that py context exec can access the command def for api logger; was just a matter of when to apply the api decorator during function creation; the command def was already being attached, but it was after decoration so the closed over inner function was not getting the command def.
