### PR TITLE
export path update

### DIFF
--- a/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsCsvPlugin.scala
+++ b/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsCsvPlugin.scala
@@ -65,13 +65,15 @@ class ExportHdfsCsvPlugin extends SparkCommandPlugin[ExportHdfsCsvArgs, ExportMe
    */
   override def execute(arguments: ExportHdfsCsvArgs)(implicit invocation: Invocation): ExportMetadata = {
 
+    def getAbsolutePath(s: String): String = engine.frames.frameFileStorage.hdfs.absolutePath(s).toString
+
     val fileStorage = new FileStorage
-    require(!fileStorage.exists(new Path(arguments.folderName)), "File or Directory already exists")
+    val artifactPath = new Path(getAbsolutePath(arguments.folderName))
+    require(!fileStorage.exists(artifactPath), "File or Directory already exists")
     val frame: SparkFrame = arguments.frame
     // load frame as RDD
     val sample = exportToHdfsCsv(frame.rdd, arguments.folderName, arguments.separator.getOrElse(','), arguments.count, arguments.offset)
 
-    val artifactPath = new Path(s"${fileStorage.hdfs.getHomeDirectory()}/${arguments.folderName}")
     ExportMetadata(artifactPath.toString, "all", "csv", frame.rowCount, sample,
       fileStorage.size(artifactPath.toString), Some(arguments.folderName))
   }

--- a/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsCsvPlugin.scala
+++ b/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsCsvPlugin.scala
@@ -65,14 +65,12 @@ class ExportHdfsCsvPlugin extends SparkCommandPlugin[ExportHdfsCsvArgs, ExportMe
    */
   override def execute(arguments: ExportHdfsCsvArgs)(implicit invocation: Invocation): ExportMetadata = {
 
-    def getAbsolutePath(s: String): String = engine.frames.frameFileStorage.hdfs.absolutePath(s).toString
-
     val fileStorage = new FileStorage
-    val artifactPath = new Path(getAbsolutePath(arguments.folderName))
+    val artifactPath = engine.frames.frameFileStorage.hdfs.absolutePath(arguments.folderName, fileStorage.hdfs.getHomeDirectory())
     require(!fileStorage.exists(artifactPath), "File or Directory already exists")
     val frame: SparkFrame = arguments.frame
     // load frame as RDD
-    val sample = exportToHdfsCsv(frame.rdd, arguments.folderName, arguments.separator.getOrElse(','), arguments.count, arguments.offset)
+    val sample = exportToHdfsCsv(frame.rdd, artifactPath, arguments.separator.getOrElse(','), arguments.count, arguments.offset)
 
     ExportMetadata(artifactPath.toString, "all", "csv", frame.rowCount, sample,
       fileStorage.size(artifactPath.toString), Some(arguments.folderName))

--- a/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsCsvPlugin.scala
+++ b/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsCsvPlugin.scala
@@ -66,11 +66,11 @@ class ExportHdfsCsvPlugin extends SparkCommandPlugin[ExportHdfsCsvArgs, ExportMe
   override def execute(arguments: ExportHdfsCsvArgs)(implicit invocation: Invocation): ExportMetadata = {
 
     val fileStorage = new FileStorage
-    val artifactPath = engine.frames.frameFileStorage.hdfs.absolutePath(arguments.folderName, fileStorage.hdfs.getHomeDirectory())
+    val artifactPath = engine.frames.frameFileStorage.hdfs.absolutePath(arguments.folderName, fileStorage.hdfs.getHomeDirectory().toString)
     require(!fileStorage.exists(artifactPath), "File or Directory already exists")
     val frame: SparkFrame = arguments.frame
     // load frame as RDD
-    val sample = exportToHdfsCsv(frame.rdd, artifactPath, arguments.separator.getOrElse(','), arguments.count, arguments.offset)
+    val sample = exportToHdfsCsv(frame.rdd, artifactPath.toString, arguments.separator.getOrElse(','), arguments.count, arguments.offset)
 
     ExportMetadata(artifactPath.toString, "all", "csv", frame.rowCount, sample,
       fileStorage.size(artifactPath.toString), Some(arguments.folderName))

--- a/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsJsonPlugin.scala
+++ b/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsJsonPlugin.scala
@@ -61,12 +61,14 @@ class ExportHdfsJsonPlugin extends SparkCommandPlugin[ExportHdfsJsonArgs, Export
    * @return value of type declared as the Return type
    */
   override def execute(arguments: ExportHdfsJsonArgs)(implicit invocation: Invocation): ExportMetadata = {
+    def getAbsolutePath(s: String): String = engine.frames.frameFileStorage.hdfs.absolutePath(s).toString
+
     val fileStorage = new FileStorage
-    require(!fileStorage.exists(new Path(arguments.folderName)), "File or Directory already exists")
+    val artifactPath = new Path(getAbsolutePath(arguments.folderName))
+    require(!fileStorage.exists(artifactPath), "File or Directory already exists")
     val frame: SparkFrame = arguments.frame
     val sample = exportToHdfsJson(frame.rdd, arguments.folderName, arguments.count, arguments.offset)
 
-    val artifactPath = new Path(s"${fileStorage.hdfs.getHomeDirectory()}/${arguments.folderName}")
     ExportMetadata(artifactPath.toString, "all", "json", frame.rowCount, sample,
       fileStorage.size(artifactPath.toString), Some(arguments.folderName))
   }

--- a/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsJsonPlugin.scala
+++ b/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsJsonPlugin.scala
@@ -64,10 +64,10 @@ class ExportHdfsJsonPlugin extends SparkCommandPlugin[ExportHdfsJsonArgs, Export
     def getAbsolutePath(s: String): String = engine.frames.frameFileStorage.hdfs.absolutePath(s).toString
 
     val fileStorage = new FileStorage
-    val artifactPath = new Path(getAbsolutePath(arguments.folderName))
+    val artifactPath = engine.frames.frameFileStorage.hdfs.absolutePath(arguments.folderName, fileStorage.hdfs.getHomeDirectory())
     require(!fileStorage.exists(artifactPath), "File or Directory already exists")
     val frame: SparkFrame = arguments.frame
-    val sample = exportToHdfsJson(frame.rdd, arguments.folderName, arguments.count, arguments.offset)
+    val sample = exportToHdfsJson(frame.rdd, artifactPath, arguments.count, arguments.offset)
 
     ExportMetadata(artifactPath.toString, "all", "json", frame.rowCount, sample,
       fileStorage.size(artifactPath.toString), Some(arguments.folderName))

--- a/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsJsonPlugin.scala
+++ b/engine-plugins/frame-plugins/src/main/scala/org/trustedanalytics/atk/engine/frame/plugins/exporthdfs/ExportHdfsJsonPlugin.scala
@@ -61,13 +61,12 @@ class ExportHdfsJsonPlugin extends SparkCommandPlugin[ExportHdfsJsonArgs, Export
    * @return value of type declared as the Return type
    */
   override def execute(arguments: ExportHdfsJsonArgs)(implicit invocation: Invocation): ExportMetadata = {
-    def getAbsolutePath(s: String): String = engine.frames.frameFileStorage.hdfs.absolutePath(s).toString
 
     val fileStorage = new FileStorage
-    val artifactPath = engine.frames.frameFileStorage.hdfs.absolutePath(arguments.folderName, fileStorage.hdfs.getHomeDirectory())
+    val artifactPath = engine.frames.frameFileStorage.hdfs.absolutePath(arguments.folderName, fileStorage.hdfs.getHomeDirectory().toString)
     require(!fileStorage.exists(artifactPath), "File or Directory already exists")
     val frame: SparkFrame = arguments.frame
-    val sample = exportToHdfsJson(frame.rdd, artifactPath, arguments.count, arguments.offset)
+    val sample = exportToHdfsJson(frame.rdd, artifactPath.toString, arguments.count, arguments.offset)
 
     ExportMetadata(artifactPath.toString, "all", "json", frame.rowCount, sample,
       fileStorage.size(artifactPath.toString), Some(arguments.folderName))

--- a/engine/engine-core/src/main/scala/org/trustedanalytics/atk/engine/FileStorage.scala
+++ b/engine/engine-core/src/main/scala/org/trustedanalytics/atk/engine/FileStorage.scala
@@ -81,7 +81,7 @@ class FileStorage extends EventLogging {
    * Path from a path
    * @param path a path relative to the root or that includes the root
    */
-  def absolutePath(path: String): Path = {
+  def absolutePath(path: String, prefix: String = EngineConfig.fsroot ): Path = {
     if (absolutePathPattern.findFirstIn(path).isDefined) {
       new Path(path)
     }

--- a/engine/engine-core/src/main/scala/org/trustedanalytics/atk/engine/FileStorage.scala
+++ b/engine/engine-core/src/main/scala/org/trustedanalytics/atk/engine/FileStorage.scala
@@ -81,12 +81,12 @@ class FileStorage extends EventLogging {
    * Path from a path
    * @param path a path relative to the root or that includes the root
    */
-  def absolutePath(path: String, prefix: String = EngineConfig.fsroot ): Path = {
+  def absolutePath(path: String, prefix: String = EngineConfig.fsRoot): Path = {
     if (absolutePathPattern.findFirstIn(path).isDefined) {
       new Path(path)
     }
     else {
-      new Path(concatPaths(EngineConfig.fsRoot, path))
+      new Path(concatPaths(prefix, path))
     }
   }
 


### PR DESCRIPTION
This does two updates, first off it changes the path processing mechanism to be precisely symmetric to the frame load, which allows for both absolute paths and relative paths.

Secondly it updates the requires to use the full target path rather than a partial.

This does have a minor functionality change, it will default to fs.root rather than homedir here. I can change that back without too much difficulty, if a little hackily.
