### PR TITLE
doc gen return type fix for single value convention

### DIFF
--- a/python-client/trustedanalytics/rest/command.py
+++ b/python-client/trustedanalytics/rest/command.py
@@ -40,8 +40,6 @@ def execute_command(command_name, selfish, **arguments):
     command_request = CommandRequest(command_name, arguments)
     command_info = executor.issue(command_request)
     result = command_info.result
-    if result.has_key('value') and len(result) == 1:
-        result = command_info.result.get('value')
     return result
 
 

--- a/python-client/trustedanalytics/rest/frame.py
+++ b/python-client/trustedanalytics/rest/frame.py
@@ -123,7 +123,7 @@ class FrameBackendRest(object):
            return ("[1]" for item in iterable if predicate(item))
         arguments = {'frame': frame.uri,
                      'udf': get_udf_arg(frame, where, icountwhere)}
-        return executor.execute("frame/count_where", self, arguments)
+        return executor.execute("frame/count_where", self, arguments)['value']
 
     def get_error_frame(self, frame):
         return self.get_frame_by_uri(self._get_frame_info(frame).error_frame_uri)

--- a/python-client/trustedanalytics/rest/graph.py
+++ b/python-client/trustedanalytics/rest/graph.py
@@ -113,11 +113,11 @@ class GraphBackendRest(object):
 
     def get_vertex_count(self, graph):
         arguments = {'graph': graph.uri}
-        return executor.execute("graph:/vertex_count", graph, arguments)
+        return executor.execute("graph:/vertex_count", graph, arguments)['value']
 
     def get_edge_count(self, graph):
         arguments = {'graph': graph.uri}
-        return executor.execute("graph:/edge_count", graph, arguments)
+        return executor.execute("graph:/edge_count", graph, arguments)['value']
 
 class GraphInfo(object):
     """


### PR DESCRIPTION
improved doc gen to account for the convention of returning an immediate from a dict with single 'value' key
