### PR TITLE
Fix namespace for spray configuration parameters

### DIFF
--- a/rest-server/src/main/resources/reference.conf
+++ b/rest-server/src/main/resources/reference.conf
@@ -42,15 +42,14 @@ slick {
   logLevel = INFO
 }
 
-spray.can.server {
-  request-timeout = ${trustedanalytics.atk.api.request-timeout}
-  ssl-encryption = off
-}
-
-# 8m is default, causes problems if UDF references large variables
-spray.can.client.parsing.max-content-length = 32m
-
 trustedanalytics.atk {
+  spray.can.server {
+    request-timeout = ${trustedanalytics.atk.api.request-timeout}
+    ssl-encryption = off
+  }
+
+  # 8m is default, causes problems if UDF references large variables
+  spray.can.client.parsing.max-content-length = 64m
 
   api {
     identifier = "ia"

--- a/rest-server/src/main/scala/org/trustedanalytics/atk/rest/RestServerConfig.scala
+++ b/rest-server/src/main/scala/org/trustedanalytics/atk/rest/RestServerConfig.scala
@@ -89,7 +89,7 @@ object RestServerConfig {
   val serviceMode: String = config.getString("trustedanalytics.atk.api.service-mode")
 
   /** Scheme for Rest Service to bind with (http or https) */
-  val schemeIsHttps: Boolean = config.getBoolean("spray.can.server.ssl-encryption")
+  val schemeIsHttps: Boolean = config.getBoolean("trustedanalytics.atk.spray.can.server.ssl-encryption")
 
   /** Location of the Java keystore file */
   val keyStoreFile: String = config.getString("trustedanalytics.atk.component.archives.rest-server.key-store-file")


### PR DESCRIPTION
Spray configuration parameters need to be under trustedanalytics.atk
namespace to be picked up.

Also increased spray.can.client.parsing.max-content-length to 64m
to support larger uploads from client
