### PR TITLE
ARX train documentation updates

### DIFF
--- a/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARXTrainPlugin.scala
+++ b/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARXTrainPlugin.scala
@@ -41,12 +41,20 @@ import org.apache.spark.mllib.ScoringJsonReaderWriters
 import scala.collection.mutable.ArrayBuffer
 
 @PluginDoc(oneLine = "Creates AutoregressionX (ARX) Model from train frame.",
-  extended = """Creating a AutoregressionX (ARX) Model using the observation columns. Note that the
-dataset being trained must be small enough to be worked with on a single node.""",
-  returns = """dictionary
-    A dictionary with trained ARX model with the following keys\:
-'c' : intercept term, or zero for no intercept
-'coefficients' : coefficients for each column of exogenous inputs.""")
+  extended = """Fit an autoregressive model with additional exogenous variables.
+
+**Notes**
+
+#)  Dataset being trained must be small enough to be worked with on a single node.
+#)  If the specified set of exogenous variables is not invertible, there will be an
+error specifying that the matrix is singular.  This happens when there are certain
+patterns in the dataset or columns of all zeros.  """,
+  returns = """A dictionary with trained ARX model with the following keys\:
+
+              |   **c** : *float*
+              |       intercept term, or zero for no intercept
+              |   **coefficients** : *list*
+              |       coefficients for each column of exogenous input.""")
 class ARXTrainPlugin extends SparkCommandPlugin[ARXTrainArgs, ARXTrainReturn] {
   /**
    * The name of the command.

--- a/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARXTrainPlugin.scala
+++ b/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARXTrainPlugin.scala
@@ -46,9 +46,11 @@ import scala.collection.mutable.ArrayBuffer
 **Notes**
 
 #)  Dataset being trained must be small enough to be worked with on a single node.
-#)  If the specified set of exogenous variables is not invertible, there will be an
-    error specifying that the matrix is singular.  This happens when there are certain
-    patterns in the dataset or columns of all zeros.
+#)  If the specified set of exogenous variables is not invertible, an exception is
+    thrown stating that the "matrix is singular".  This happens when there are
+    certain patterns in the dataset or columns of all zeros.  In order to work
+    around the singular matrix issue, try selecting a different set of columns for
+    exogenous variables, or use a different time window for training.
 """,
   returns = """A dictionary with trained ARX model with the following keys\:
 

--- a/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARXTrainPlugin.scala
+++ b/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARXTrainPlugin.scala
@@ -54,7 +54,7 @@ import scala.collection.mutable.ArrayBuffer
 """,
   returns = """A dictionary with trained ARX model with the following keys\:
 
-              |   **c** : *float*
+              |   **c** : *float64*
               |       intercept term, or zero for no intercept
               |   **coefficients** : *list*
               |       coefficients for each column of exogenous input.""")

--- a/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARXTrainPlugin.scala
+++ b/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARXTrainPlugin.scala
@@ -47,8 +47,9 @@ import scala.collection.mutable.ArrayBuffer
 
 #)  Dataset being trained must be small enough to be worked with on a single node.
 #)  If the specified set of exogenous variables is not invertible, there will be an
-error specifying that the matrix is singular.  This happens when there are certain
-patterns in the dataset or columns of all zeros.  """,
+    error specifying that the matrix is singular.  This happens when there are certain
+    patterns in the dataset or columns of all zeros.
+""",
   returns = """A dictionary with trained ARX model with the following keys\:
 
               |   **c** : *float*


### PR DESCRIPTION
Updating ARX train documentation to fix return value description, and add a note about the "matrix is singular" error
