### PR TITLE
DPNG-7606 allowing spark submit process to exit

### DIFF
--- a/engine/engine-core/src/main/scala/org/trustedanalytics/atk/engine/command/SparkSubmitLauncher.scala
+++ b/engine/engine-core/src/main/scala/org/trustedanalytics/atk/engine/command/SparkSubmitLauncher.scala
@@ -43,7 +43,7 @@ class SparkSubmitLauncher(engine: Engine) extends EventLogging with EventLogging
 
   lazy val hdfsFileStorage: FileStorage = engine.asInstanceOf[EngineImpl].fileStorage
 
-  def execute(moduleName: String, jobContext: JobContext)(implicit invocation: Invocation): Int = {
+  def execute(moduleName: String, jobContext: JobContext)(implicit invocation: Invocation): Unit = {
     withContext("executeCommandOnYarn") {
 
       try {
@@ -140,7 +140,6 @@ class SparkSubmitLauncher(engine: Engine) extends EventLogging with EventLogging
           }
         })
         info(s"Completed with exitCode:$result, ${JvmMemory.memory}")
-        result
 
       }
       finally {

--- a/engine/interfaces/src/main/resources/reference.conf
+++ b/engine/interfaces/src/main/resources/reference.conf
@@ -224,6 +224,10 @@ trustedanalytics.atk {
           spark.driver.extraLibraryPath = "."
           spark.executor.extraLibraryPath = "."
 
+          # In YARN cluster mode, controls whether the client waits to exit until the application completes.
+          # If set to true, the client process will stay alive reporting the application's status.
+          # Otherwise, the client process will exit after submission.
+          spark.yarn.submit.waitAppCompletion = false
         }
 
       }


### PR DESCRIPTION
allowing spark submit process to exit so that less memory will be used by rest server
