### PR TITLE
Fix import from OrientDB to TAP analytics toolkit graph

### DIFF
--- a/conf/examples/application.conf.tpl
+++ b/conf/examples/application.conf.tpl
@@ -55,7 +55,7 @@ trustedanalytics.atk {
     //connection-orientdb.username = "invalid-orientdb-user"
     //connection-orientdb.password = "invalid-orientdb-password"
     //connection-orientdb.url = "remote:"${trustedanalytics.atk.datastore.connection-orientdb.host}":"${trustedanalytics.atk.datastore.connection-orientdb.port}
-    // connection-orientdb.rootpassword = "invalid-orientdb-rootpassword"
+    //connection-orientdb.rootpassword = "invalid-orientdb-rootpassword"
   }
 
   engine {

--- a/engine-plugins/graph-plugins/src/main/scala/org/trustedanalytics/atk/plugins/orientdb/GraphDbFactory.scala
+++ b/engine-plugins/graph-plugins/src/main/scala/org/trustedanalytics/atk/plugins/orientdb/GraphDbFactory.scala
@@ -88,11 +88,12 @@ object GraphDbFactory extends EventLogging {
    */
   private def openGraphDb(orientDb: ODatabaseDocumentTx, dbConfigurations: DbConfiguration): OrientGraphNoTx = {
     Try {
-      val db: ODatabaseDocumentTx = orientDb.open(dbConfigurations.dbUserName, dbConfigurations.dbUserName)
+      val db: ODatabaseDocumentTx = orientDb.open(dbConfigurations.dbUserName, dbConfigurations.dbPassword)
       db
     } match {
       case Success(db) => new OrientGraphNoTx(db)
       case Failure(ex) =>
+        println("stack" + ex.printStackTrace())
         error(s"Unable to open database", exception = ex)
         throw new scala.RuntimeException(s"Unable to open database: ${dbConfigurations.dbUri}, ${ex.getMessage}")
     }

--- a/engine-plugins/graph-plugins/src/test/scala/org/trustedanalytics/atk/plugins/orientdb/DataTypeToOTypeConversionTest.scala
+++ b/engine-plugins/graph-plugins/src/test/scala/org/trustedanalytics/atk/plugins/orientdb/DataTypeToOTypeConversionTest.scala
@@ -21,7 +21,13 @@ import scala.collection.mutable.ArrayBuffer
 
 class DataTypeToOTypeConversionTest extends WordSpec with Matchers {
 
-  val columns = List(Column(GraphSchema.vidProperty, DataTypes.int64), Column(GraphSchema.labelProperty, DataTypes.string), Column("name", DataTypes.string), Column("from", DataTypes.string), Column("to", DataTypes.string), Column("fair", DataTypes.int32))
+  val columns = List(
+    Column(GraphSchema.vidProperty, DataTypes.int64),
+    Column(GraphSchema.labelProperty, DataTypes.string),
+    Column("name", DataTypes.string),
+    Column("from", DataTypes.string),
+    Column("to", DataTypes.string),
+    Column("fair", DataTypes.int32))
   val schema = new VertexSchema(columns, GraphSchema.labelProperty, null)
   val orientTypeBuffer = new ArrayBuffer[String]()
   val dataTypeBuffer = new ArrayBuffer[String]()
@@ -30,7 +36,6 @@ class DataTypeToOTypeConversionTest extends WordSpec with Matchers {
     "Convert DataTypes to OrientDb OTypes" in {
 
       columns.foreach(col => {
-        val colName = col.name
         val colDataType = col.dataType
         // call method under test
         val orientColumnDataType = OrientDbTypeConverter.convertDataTypeToOrientDbType(colDataType)

--- a/engine-plugins/graph-plugins/src/test/scala/org/trustedanalytics/atk/plugins/orientdb/EdgeFrameWriterTest.scala
+++ b/engine-plugins/graph-plugins/src/test/scala/org/trustedanalytics/atk/plugins/orientdb/EdgeFrameWriterTest.scala
@@ -35,8 +35,14 @@ class EdgeFrameWriterTest extends WordSpec with TestingSparkContextWordSpec with
   "Edge frame writer" should {
     "Export edge frame" in {
       // exporting a vertex frame:
-      val dbConfig = new DbConfiguration(dbUri, dbUserName, dbUserName, "port", "host", rootPassword)
-      val vColumns = List(Column(GraphSchema.vidProperty, DataTypes.int64), Column(GraphSchema.labelProperty, DataTypes.string), Column("name", DataTypes.string), Column("from", DataTypes.string), Column("to", DataTypes.string), Column("fair", DataTypes.int32))
+      val dbConfig = new DbConfiguration(dbUri, dbUserName, dbPassword, "port", "host", rootPassword)
+      val vColumns = List(
+        Column(GraphSchema.vidProperty, DataTypes.int64),
+        Column(GraphSchema.labelProperty, DataTypes.string),
+        Column("name", DataTypes.string),
+        Column("from", DataTypes.string),
+        Column("to", DataTypes.string),
+        Column("fair", DataTypes.int32))
       val vSchema = new VertexSchema(vColumns, GraphSchema.labelProperty, null)
 
       val vertices: List[Row] = List(
@@ -52,10 +58,15 @@ class EdgeFrameWriterTest extends WordSpec with TestingSparkContextWordSpec with
         val oVertexType = schemaWriter.createVertexSchema(vSchema)
       }
       val vertexFrameWriter = new VertexFrameWriter(vertexFrameRdd, dbConfig)
-      val verticesCountRdd = vertexFrameWriter.exportVertexFrame(vBatchSize)
+      val verticesCount = vertexFrameWriter.exportVertexFrame(vBatchSize)
 
       //exporting the edge frame:
-      val eColumns = List(Column(GraphSchema.edgeProperty, DataTypes.int64), Column(GraphSchema.srcVidProperty, DataTypes.int64), Column(GraphSchema.destVidProperty, DataTypes.int64), Column(GraphSchema.labelProperty, DataTypes.string), Column("distance", DataTypes.int32))
+      val eColumns = List(
+        Column(GraphSchema.edgeProperty, DataTypes.int64),
+        Column(GraphSchema.srcVidProperty, DataTypes.int64),
+        Column(GraphSchema.destVidProperty, DataTypes.int64),
+        Column(GraphSchema.labelProperty, DataTypes.string),
+        Column("distance", DataTypes.int32))
       val eSchema = new EdgeSchema(eColumns, "label", "srclabel", "destlabel")
       val edges: List[Row] = List(
         new GenericRow(Array(1L, 1L, 2L, "distance1", 100)),

--- a/engine-plugins/graph-plugins/src/test/scala/org/trustedanalytics/atk/plugins/orientdb/EdgeWriterTest.scala
+++ b/engine-plugins/graph-plugins/src/test/scala/org/trustedanalytics/atk/plugins/orientdb/EdgeWriterTest.scala
@@ -32,7 +32,13 @@ class EdgeWriterTest extends WordSpec with Matchers with TestingSparkContextWord
   "Edge writer" should {
     "export edge to Orient edge" in {
       //create the source and destination vertices
-      val columns = List(Column(GraphSchema.vidProperty, DataTypes.int64), Column(GraphSchema.labelProperty, DataTypes.string), Column("name", DataTypes.string), Column("from", DataTypes.string), Column("to", DataTypes.string), Column("fair", DataTypes.int32))
+      val columns = List(
+        Column(GraphSchema.vidProperty, DataTypes.int64),
+        Column(GraphSchema.labelProperty, DataTypes.string),
+        Column("name", DataTypes.string),
+        Column("from", DataTypes.string),
+        Column("to", DataTypes.string),
+        Column("fair", DataTypes.int32))
       val schema = new VertexSchema(columns, GraphSchema.labelProperty, null)
       val rowSrc = new GenericRow(Array(1L, "l1", "Bob", "PDX", "LAX", 350))
       val rowDest = new GenericRow(Array(2L, "l1", "Alice", "SFO", "SEA", 465))
@@ -42,7 +48,12 @@ class EdgeWriterTest extends WordSpec with Matchers with TestingSparkContextWord
       val orientVertexSrc = vertexWriter.addVertex(vertexSrc)
       val orientVertexDest = vertexWriter.addVertex(vertexDest)
       // create the edge
-      val edgeColumns = List(Column(GraphSchema.edgeProperty, DataTypes.int64), Column(GraphSchema.srcVidProperty, DataTypes.int64), Column(GraphSchema.destVidProperty, DataTypes.int64), Column(GraphSchema.labelProperty, DataTypes.string), Column("distance", DataTypes.int32))
+      val edgeColumns = List(
+        Column(GraphSchema.edgeProperty, DataTypes.int64),
+        Column(GraphSchema.srcVidProperty, DataTypes.int64),
+        Column(GraphSchema.destVidProperty, DataTypes.int64),
+        Column(GraphSchema.labelProperty, DataTypes.string),
+        Column("distance", DataTypes.int32))
       val edgeSchema = new EdgeSchema(edgeColumns, "label", "srclabel", "destlabel")
       val edgeRow = new GenericRow(Array(1L, 2L, 3L, "distance", 500))
       val edge = Edge(edgeSchema, edgeRow)

--- a/engine-plugins/graph-plugins/src/test/scala/org/trustedanalytics/atk/plugins/orientdb/VertexFrameWriterTest.scala
+++ b/engine-plugins/graph-plugins/src/test/scala/org/trustedanalytics/atk/plugins/orientdb/VertexFrameWriterTest.scala
@@ -34,7 +34,13 @@ class VertexFrameWriterTest extends WordSpec with TestingSparkContextWordSpec wi
   "vertex frame writer" should {
     "export vertex frame to OrientDB" in {
       val dbConfig = new DbConfiguration(dbUri, dbUserName, dbPassword, "port", "host", rootPassword)
-      val columns = List(Column(GraphSchema.vidProperty, DataTypes.int64), Column(GraphSchema.labelProperty, DataTypes.string), Column("name", DataTypes.string), Column("from", DataTypes.string), Column("to", DataTypes.string), Column("fair", DataTypes.int32))
+      val columns = List(
+        Column(GraphSchema.vidProperty, DataTypes.int64),
+        Column(GraphSchema.labelProperty, DataTypes.string),
+        Column("name", DataTypes.string),
+        Column("from", DataTypes.string),
+        Column("to", DataTypes.string),
+        Column("fair", DataTypes.int32))
       val schema = new VertexSchema(columns, GraphSchema.labelProperty, null)
       val vertices: List[Row] = List(
         new GenericRow(Array(1L, "l1", "Bob", "PDX", "LAX", 350)),

--- a/engine-plugins/graph-plugins/src/test/scala/org/trustedanalytics/atk/plugins/orientdb/VertexWriterTest.scala
+++ b/engine-plugins/graph-plugins/src/test/scala/org/trustedanalytics/atk/plugins/orientdb/VertexWriterTest.scala
@@ -34,7 +34,13 @@ class VertexWriterTest extends WordSpec with Matchers with TestingSparkContextWo
 
   "Vertex Writer" should {
     val vertex = {
-      val columns = List(Column(GraphSchema.vidProperty, DataTypes.int64), Column(GraphSchema.labelProperty, DataTypes.string), Column("name", DataTypes.string), Column("from", DataTypes.string), Column("to", DataTypes.string), Column("fair", DataTypes.int32))
+      val columns = List(
+        Column(GraphSchema.vidProperty, DataTypes.int64),
+        Column(GraphSchema.labelProperty, DataTypes.string),
+        Column("name", DataTypes.string),
+        Column("from", DataTypes.string),
+        Column("to", DataTypes.string),
+        Column("fair", DataTypes.int32))
       val schema = new VertexSchema(columns, GraphSchema.labelProperty, null)
       val row = new GenericRow(Array(1L, "l1", "Bob", "PDX", "LAX", 350))
       Vertex(schema, row)

--- a/package/config/trustedanalytics-tar/application.conf
+++ b/package/config/trustedanalytics-tar/application.conf
@@ -66,8 +66,8 @@ trustedanalytics.atk {
   #OrientDB
       connection-orientdb.host = ${ORIENTDB_HOST}
       connection-orientdb.port = ${ORIENTDB_PORT}
-      connection-orientdb.username = ${ORIENTDB_USER}
-      connection-orientdb.password = ${ORIENTDB_PASS}
+      connection-orientdb.username = "admin"
+      connection-orientdb.password = "admin"
       connection-orientdb.url = "remote:"${trustedanalytics.atk.datastore.connection-orientdb.host}":"${trustedanalytics.atk.datastore.connection-orientdb.port}
       connection-orientdb.rootpassword = ${ORIENTDB_ROOTPASS}
   }

--- a/package/config/trustedanalytics-tar/rest-server.sh
+++ b/package/config/trustedanalytics-tar/rest-server.sh
@@ -85,8 +85,6 @@ export POSTGRES_URL=$PG_URL
 #OrientDB
 export ORIENTDB_HOST=$(echo $VCAP_SERVICES | $jq -c -r '.orientdb | .[0].credentials.hostname')
 export ORIENTDB_PORT=$(echo $VCAP_SERVICES | $jq -c -r '.orientdb | .[0].credentials.ports["2424/tcp"]')
-export ORIENTDB_USER=$(echo $VCAP_SERVICES | $jq -c -r '.orientdb | .[0].credentials.username')
-export ORIENTDB_PASS=$(echo $VCAP_SERVICES | $jq -c -r '.orientdb | .[0].credentials.password')
 export ORIENTDB_ROOTPASS=$(echo $VCAP_SERVICES | $jq -c -r '.orientdb | .[0].credentials.password')
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ export MAVEN_OPTS="-Xmx512m -XX:PermSize=256m"
         <dep.hive.version>1.1.0-${dep.cdh.version}</dep.hive.version>
         <dev.spark.hive.version>1.5.0-${dep.cdh.version}</dev.spark.hive.version>
         <dep.daal.version>2016.2.181</dep.daal.version>
-        <dep.orientdb.version>2.1.12</dep.orientdb.version>
+        <dep.orientdb.version>2.1.16</dep.orientdb.version>
 
         <!--START GAO MAVEN -->
 

--- a/python-client/trustedanalytics/core/graph.py
+++ b/python-client/trustedanalytics/core/graph.py
@@ -433,6 +433,8 @@ Default is None.""")
             self.uri = _info.uri
         else:
             self.uri = self._backend.create(self, name, 'atk/frame', _info)
+        if isinstance(source, OrientDBGraph):
+            self._backend._import_orientdb(self,source)
 
         self._vertices = GraphFrameCollection(self, "vertices", self._get_vertex_frame, self._get_vertex_frames)
         self._edges = GraphFrameCollection(self, "edges", self._get_edge_frame, self._get_edge_frames)


### PR DESCRIPTION
- Update Python API to call import OrientDB plugin.
- Update OrientDB version to match TAP 0.7 deployment
- Update connection config for TAP
