### PR TITLE
Removing timeseries values parameter from ARIMA predict.

### DIFF
--- a/doc-api-examples/src/main/resources/python/model-arima/new.rst
+++ b/doc-api-examples/src/main/resources/python/model-arima/new.rst
@@ -80,9 +80,11 @@ Train the model using the timeseries frame:
 <progress>
 {u'coefficients': [9.864444620964322, 0.2848511106449633, 0.47346114378593795]}
 
-Call predict to future periods:
+Call predict to forecast values by passing the number of future periods to predict beyond the length of the time series.
+Since the parameter in this example is 0, predict will forecast 7 values (the same number of values that were in the
+original time series vector).
 
->>> model.predict(ts_values, 0)
+>>> model.predict(0)
 <progress>
 {u'forecasted': [12.674342627141744,
   13.638048984791693,
@@ -110,17 +112,17 @@ Post a request to get the metadata about the model.
 u'{"model_details":{"model_type":"ARIMA Model","model_class":"com.cloudera.sparkts.models.ARIMAModel","model_reader":"org.trustedanalytics.atk.scoring.models.ARIMAModelReaderPlugin","custom_values":{}},"input":[{"name":"timeseries","value":"Array[Double]"},{"name":"future","value":"Int"}],"output":[{"name":"timeseries","value":"Array[Double]"},{"name":"future","value":"Int"},{"name":"predicted_values","value":"Array[Double]"}]}'
 </skip>
 
-The ARIMA model only supports version 2 of the scoring engine.  In the following example, we send the historical
-time series value and specify to forecast 0 periods beyond the length of the time series provided.  This means that
+The ARIMA model only supports version 2 of the scoring engine.  We send the number of values
+to forecast beyond the length of the time series (in this example we are passing 0).  This means that
 since 7 historical time series values were provided, 7 future periods will be forecasted.
 
 <skip>
->>> r = requests.post('http://mymodel.demotrustedanalytics.com/v2/score',json={"records":[{"timeseries":[12.88969427,13.54964408,13.8432745,12.13843611,12.81156092,14.2499628,15.12102595],"future":0}]})
+>>> r = requests.post('http://mymodel.demotrustedanalytics.com/v2/score',json={"records":[{"future":0}]})
 </skip>
 
 The 'predicted_values' array contains the future values, which have been forecasted based on the historical data.
 
 <skip>
 >>> r.text
-u'{"data":[{"timeseries":[12.88969427,13.54964408,13.8432745,12.13843611,12.81156092,14.2499628,15.12102595],"future":0.0,"predicted_values":[12.674342627141744,13.638048984791693,13.682219498657313,13.883970022400577,12.49564914570843,13.66340392811346,14.201275185574925]}]}'
+u'{"data":[{"future":0.0,"predicted_values":[12.674342627141744,13.638048984791693,13.682219498657313,13.883970022400577,12.49564914570843,13.66340392811346,14.201275185574925]}]}'
 </skip>

--- a/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARIMAJsonProtocol.scala
+++ b/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARIMAJsonProtocol.scala
@@ -66,9 +66,9 @@ object ARIMAJsonProtocol {
     }
   }
 
-  implicit val arimaPredictArgsFormat = jsonFormat3(ARIMAPredictArgs)
+  implicit val arimaPredictArgsFormat = jsonFormat2(ARIMAPredictArgs)
   implicit val arimaPredictReturnFormat = jsonFormat1(ARIMAPredictReturn)
   implicit val arimaTrainArgsFormat = jsonFormat8(ARIMATrainArgs)
   implicit val arimaTrainReturnFormat = jsonFormat1(ARIMATrainReturn)
-  implicit val arimaDataFormat = jsonFormat1(ARIMAData)
+  implicit val arimaDataFormat = jsonFormat2(ARIMAData)
 }

--- a/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARIMAPredictArgs.scala
+++ b/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARIMAPredictArgs.scala
@@ -23,10 +23,8 @@ import org.trustedanalytics.atk.engine.plugin.ArgDoc
  * Parameters used for predicting future values using the ARIMA Model
  */
 case class ARIMAPredictArgs(model: ModelReference,
-                            @ArgDoc("""Time series values to use as the gold standard.""") timeseriesValues: List[Double],
                             @ArgDoc("""Number of periods in the future to forecast (beyond the length the time series)""") futurePeriods: Int) {
   require(model != null, "model is required")
-  require(timeseriesValues != null && timeseriesValues.nonEmpty, "List of time series values must not be empty nor empty")
   require(futurePeriods >= 0, "Number of future periods should be greater than or equal to 0.")
 }
 

--- a/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARIMAPredictPlugin.scala
+++ b/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARIMAPredictPlugin.scala
@@ -72,9 +72,10 @@ class ARIMAPredictPlugin extends SparkCommandPlugin[ARIMAPredictArgs, ARIMAPredi
     // Extract the ARIMAModel from the stored JsObject
     val arimaData = model.data.convertTo[ARIMAData]
     val arimaModel = arimaData.arimaModel
+    val tsValues = arimaData.tsValues.toArray
 
     // Call ARIMA model to forecast values using the specified golden values
-    val forecasted = arimaModel.forecast(new DenseVector(arguments.timeseriesValues.toArray), arguments.futurePeriods).toArray
+    val forecasted = arimaModel.forecast(new DenseVector(tsValues), arguments.futurePeriods).toArray
 
     new ARIMAPredictReturn(forecasted)
   }

--- a/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARIMATrainPlugin.scala
+++ b/engine-plugins/model-plugins/src/main/scala/org/trustedanalytics/atk/engine/model/plugins/timeseries/ARIMATrainPlugin.scala
@@ -48,7 +48,7 @@ class ARIMATrainPlugin extends SparkCommandPlugin[ARIMATrainArgs, ARIMATrainRetu
     val arimaModel = ARIMA.fitModel(arguments.p, arguments.d, arguments.q, new DenseVector(arguments.timeseriesValues.toArray),
       arguments.includeIntercept, arguments.method, userInitParams)
 
-    val jsonModel = new ARIMAData(arimaModel)
+    val jsonModel = new ARIMAData(arimaModel, arguments.timeseriesValues)
     model.data = jsonModel.toJson.asJsObject
 
     new ARIMATrainReturn(arimaModel.coefficients)

--- a/scoring-models/src/main/scala/org/apache/spark/mllib/ScoringJsonReaderWriters.scala
+++ b/scoring-models/src/main/scala/org/apache/spark/mllib/ScoringJsonReaderWriters.scala
@@ -1146,7 +1146,8 @@ object ScoringJsonReaderWriters {
      */
     override def write(obj: ARIMAData): JsValue = {
       val model = ARIMAModelFormat.write(obj.arimaModel)
-      JsObject("arima_model" -> model)
+      JsObject("arima_model" -> model,
+        "ts_values" -> obj.tsValues.toJson)
     }
 
     /**
@@ -1160,7 +1161,8 @@ object ScoringJsonReaderWriters {
         ARIMAModelFormat.read(v)
       }
       ).get
-      new ARIMAData(model)
+      val tsValues = getOrInvalid(fields, "ts_values").convertTo[List[Double]]
+      new ARIMAData(model, tsValues)
     }
   }
 }

--- a/scoring-models/src/main/scala/org/trustedanalytics/atk/scoring/models/ARIMAData.scala
+++ b/scoring-models/src/main/scala/org/trustedanalytics/atk/scoring/models/ARIMAData.scala
@@ -21,6 +21,7 @@ import com.cloudera.sparkts.models.ARIMAModel
 /**
  * ARIMAData class
  */
-case class ARIMAData(arimaModel: ARIMAModel) {
+case class ARIMAData(arimaModel: ARIMAModel, tsValues: List[Double]) {
   require(arimaModel != null, "arimaModel must not be null.")
+  require(tsValues != null && tsValues.nonEmpty, "tsValues must not be null or empty.")
 }

--- a/scoring-models/src/main/scala/org/trustedanalytics/atk/scoring/models/ARIMAScoreModel.scala
+++ b/scoring-models/src/main/scala/org/trustedanalytics/atk/scoring/models/ARIMAScoreModel.scala
@@ -31,26 +31,25 @@ class ARIMAScoreModel(arimaModel: ARIMAModel, arimaData: ARIMAData) extends ARIM
    * @return Predicted values
    */
   override def score(data: Array[Any]): Array[Any] = {
-    if (data.length < 2)
-      throw new RuntimeException(s"Unexpected data length (${data.length.toString}). At least 2 values are required.")
+    if (data.length != 1)
+      throw new IllegalArgumentException(s"Unexpected data length (${data.length.toString}). Only 1 value was expected.")
 
     // This socring model only supports the scoring engine v2, and expects that the data array passed in contains:
-    //  (0) a List[Double] of time series values
     //  (1) an integer for the number of future values to forecast
-    if (data.length != 2)
-      throw new IllegalArgumentException(s"Unexpected number of elements in the data array.  The ARIMA score model expects 2 elements, but received ${data.length}")
+    if (data.length != 1)
+      throw new IllegalArgumentException(s"Unexpected number of elements in the data array.  The ARIMA score model expects 1 element, but received ${data.length}")
 
-    if (data(0).isInstanceOf[List[Double]] == false)
-      throw new IllegalArgumentException(s"The ARIMA score model expects the first item in the data array to be a List[Double].  Instead received ${data(0).getClass.getSimpleName}.")
+    if (data(0).isInstanceOf[Int] == false)
+      throw new IllegalArgumentException(s"The ARIMA score model expects the item in the data array to be an integer.  Instead received ${data(0).getClass.getSimpleName}.")
 
-    val timeseries = new DenseVector(data(0).asInstanceOf[List[Double]].map(ScoringModelUtils.asDouble(_)).toArray)
-    val futurePeriods = ScoringModelUtils.asInt(data(1))
+    val timeseries = new DenseVector(arimaData.tsValues.toArray)
+    val futurePeriods = ScoringModelUtils.asInt(data(0))
 
     data :+ forecast(timeseries, futurePeriods).toArray
   }
 
   override def input(): Array[Field] = {
-    Array[Field](Field("timeseries", "Array[Double]"), Field("future", "Int"))
+    Array[Field](Field("future", "Int"))
   }
 
   override def modelMetadata(): ModelMetaDataArgs = {

--- a/scoring-models/src/test/scala/org/trustedanalytics/atk/scoring/models/ARIMAScoreModelTest.scala
+++ b/scoring-models/src/test/scala/org/trustedanalytics/atk/scoring/models/ARIMAScoreModelTest.scala
@@ -27,7 +27,8 @@ class ARIMAScoreModelTest extends WordSpec {
   val coefficients = Array[Double](9.864444620964322, 0.2848511106449633, 0.47346114378593795)
   val hasIntercept = true
   val arimaModel = new ARIMAModel(p, d, q, coefficients, hasIntercept)
-  val arimaData = new ARIMAData(arimaModel)
+  val tsValues = List[Double](12.88969427, 13.54964408, 13.8432745, 12.13843611, 12.81156092, 14.2499628, 15.12102595)
+  val arimaData = new ARIMAData(arimaModel, tsValues)
   val arimaScoreModel = new ARIMAScoreModel(arimaModel, arimaData)
 
   "ARIMAScoreModel" should {
@@ -41,18 +42,16 @@ class ARIMAScoreModelTest extends WordSpec {
         arimaScoreModel.score(Array[Any](12.88969427, 13.54964408, 13.8432745, 12.13843611, 12.81156092, 14.2499628, 5))
       }
       intercept[IllegalArgumentException] {
-        arimaScoreModel.score(Array[Any](List[Double](12.88969427, 13.54964408, 13.8432745, 12.13843611, 12.81156092, 14.2499628), 5.5))
+        arimaScoreModel.score(Array[Any](5.5))
       }
     }
 
-    "score a model when valid data is passed as an array and integer (v2 format)" in {
-      val goldenValues = List[Any](12.88969427, 13.54964408, 13.8432745, 12.13843611, 12.81156092, 14.2499628, 15.12102595)
+    "score a model when valid data is passed as an integer (v2 format)" in {
       val future = 1 // number of future periods to predict, beyond the length of the golden time series
 
-      // Input array contains the golden values and number of future periods
-      var input = new Array[Any](2)
-      input(0) = goldenValues
-      input(1) = future
+      // Input array contains the number of future periods
+      var input = new Array[Any](1)
+      input(0) = future
 
       // Call score model to predict
       val output = arimaScoreModel.score(input)
@@ -61,7 +60,7 @@ class ARIMAScoreModelTest extends WordSpec {
       // grab the array of predictions from the last element in the output
       assert(output(output.length - 1).isInstanceOf[Array[Double]])
       val predictions = output(output.length - 1).asInstanceOf[Array[Double]].toList
-      assert(predictions.length == (goldenValues.length + future))
+      assert(predictions.length == (tsValues.length + future))
       assert(predictions.sameElements(List(12.674342627141744, 13.536088349647843, 13.724075785996275,
         13.807716737252422, 13.322091628390751, 13.51383197812193, 13.923562351193734, 13.830586820836254)))
     }


### PR DESCRIPTION
Instead, ARIMA predict() will use the same timeseries values that were used for training the model.
