### PR TITLE
Delete temp directory used for model extraction

### DIFF
--- a/model-publish-format/src/main/scala/org/trustedanalytics/atk/model/publish/format/ModelPublishFormat.scala
+++ b/model-publish-format/src/main/scala/org/trustedanalytics/atk/model/publish/format/ModelPublishFormat.scala
@@ -33,6 +33,7 @@ object ModelPublishFormat extends EventLogging {
 
   val modelDataString = "modelData"
   val modelReaderString = "modelReader"
+  var tempModelDir = ""
 
   /**
    * Write a Model to a our special format that can be read later by a Scoring Engine.
@@ -82,9 +83,13 @@ object ModelPublishFormat extends EventLogging {
     var byteArray: Array[Byte] = null
     var libraryPaths: Set[String] = Set.empty[String]
 
+    //Delete old temp directory if exists where model tar was extracted.
+    FileUtils.deleteQuietly(new File(tempModelDir))
+
     try {
       // Extract files to temporary directory so that dynamic library names are not changed
       val tempDirectory = getTemporaryDirectory
+      tempModelDir = tempDirectory.toString
       tarFile = new TarArchiveInputStream(new FileInputStream(modelArchiveInput))
 
       var entry = tarFile.getNextTarEntry

--- a/model-publish-format/src/main/scala/org/trustedanalytics/atk/model/publish/format/ModelPublishFormat.scala
+++ b/model-publish-format/src/main/scala/org/trustedanalytics/atk/model/publish/format/ModelPublishFormat.scala
@@ -83,9 +83,6 @@ object ModelPublishFormat extends EventLogging {
     var byteArray: Array[Byte] = null
     var libraryPaths: Set[String] = Set.empty[String]
 
-    //Delete old temp directory if exists where model tar was extracted.
-    FileUtils.deleteQuietly(new File(tempModelDir))
-
     try {
       // Extract files to temporary directory so that dynamic library names are not changed
       val tempDirectory = getTemporaryDirectory
@@ -204,6 +201,9 @@ object ModelPublishFormat extends EventLogging {
 
   private def getTemporaryDirectory: Path = {
     try {
+      //Delete old temp directory if exists where model tar was extracted.
+      FileUtils.deleteQuietly(new File(tempModelDir))
+
       val config = ConfigFactory.load(this.getClass.getClassLoader)
       val configKey = "atk.scoring-engine.tmpdir"
 


### PR DESCRIPTION
This pull request implements - cleaning up disk space when every time new model is being read by  ModelPublishFormat. This is especially useful during scoring engine model revise api is being called repetitively which will avoid disk space being filled up.
