### PR TITLE
Delete temp directory used for model extraction

### DIFF
--- a/model-publish-format/src/main/scala/org/trustedanalytics/atk/model/publish/format/ModelPublishFormat.scala
+++ b/model-publish-format/src/main/scala/org/trustedanalytics/atk/model/publish/format/ModelPublishFormat.scala
@@ -81,10 +81,11 @@ object ModelPublishFormat extends EventLogging {
     var urls = Array.empty[URL]
     var byteArray: Array[Byte] = null
     var libraryPaths: Set[String] = Set.empty[String]
+    var tempDirectory: Path = null
 
     try {
       // Extract files to temporary directory so that dynamic library names are not changed
-      val tempDirectory = getTemporaryDirectory
+      tempDirectory = getTemporaryDirectory
       tarFile = new TarArchiveInputStream(new FileInputStream(modelArchiveInput))
 
       var entry = tarFile.getNextTarEntry
@@ -130,6 +131,7 @@ object ModelPublishFormat extends EventLogging {
     }
     finally {
       IOUtils.closeQuietly(tarFile)
+      FileUtils.deleteQuietly(new File(tempDirectory.toString))
     }
 
   }


### PR DESCRIPTION
This pull request implements - cleaning up temp directory when every time new model is being read by ModelPublishFormat. This is especially useful during scoring engine model revise api is being called repetitively which will avoid disk space being filled up.
