### PR TITLE
Update spark-timeseries version to 0.3.5 with Augmented Dickey-Fuller Fix

### DIFF
--- a/doc-api-examples/src/main/resources/python/frame/timeseries_augmented_dickey_fuller_test.rst
+++ b/doc-api-examples/src/main/resources/python/frame/timeseries_augmented_dickey_fuller_test.rst
@@ -57,7 +57,7 @@ Calcuate the augmented Dickey-Fuller test statistic for column "b" with no lag:
 <progress>
 
 >>> result["p_value"]
-0.7317795217142998
+0.8318769375509645
 
 >>> result["test_stat"]
--1.0573441288025922
+-0.7553870955614206

--- a/doc-api-examples/src/main/resources/python/frame/timeseries_augmented_dickey_fuller_test.rst
+++ b/doc-api-examples/src/main/resources/python/frame/timeseries_augmented_dickey_fuller_test.rst
@@ -56,8 +56,17 @@ Calcuate the augmented Dickey-Fuller test statistic for column "b" with no lag:
 >>> result = frame.timeseries_augmented_dickey_fuller_test("b", 0)
 <progress>
 
+<skip>
 >>> result["p_value"]
 0.8318769375509645
 
 >>> result["test_stat"]
 -0.7553870955614206
+</skip>
+
+<hide>
+>>> # Check if p-value and test statistic are almost equal
+>>> tolerance = 0.0001
+>>> assert(abs(result["p_value"] - 0.8318769375509645) < tolerance)
+>>> assert(abs(result["test_stat"] - -0.7553870955614206) < tolerance)
+</hide>

--- a/doc-api-examples/src/main/resources/python/frame/timeseries_augmented_dickey_fuller_test.rst
+++ b/doc-api-examples/src/main/resources/python/frame/timeseries_augmented_dickey_fuller_test.rst
@@ -56,17 +56,8 @@ Calcuate the augmented Dickey-Fuller test statistic for column "b" with no lag:
 >>> result = frame.timeseries_augmented_dickey_fuller_test("b", 0)
 <progress>
 
-<skip>
 >>> result["p_value"]
-0.8318769375509645
+0.8318769494612004
 
 >>> result["test_stat"]
--0.7553870955614206
-</skip>
-
-<hide>
->>> # Check if p-value and test statistic are almost equal
->>> tolerance = 0.0001
->>> assert(abs(result["p_value"] - 0.8318769375509645) < tolerance)
->>> assert(abs(result["test_stat"] - -0.7553870955614206) < tolerance)
-</hide>
+-0.7553870527334429

--- a/pom.xml
+++ b/pom.xml
@@ -1589,7 +1589,7 @@ export MAVEN_OPTS="-Xmx512m -XX:PermSize=256m"
             <dependency>
                 <groupId>com.cloudera.sparkts</groupId>
                 <artifactId>sparkts</artifactId>
-                <version>0.3.4</version>
+                <version>0.3.5</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>breeze_${scala.short.version}</artifactId>


### PR DESCRIPTION
Updated pom.xml to use sparkts 0.3.5, which includes a fix in the Augmented-Dickey Fuller time series statistics test.  Also, updated the ADF doc example to reflect the fixed value.
