### PR TITLE
Update to sparkts 0.3.5, which includes ADF test fix

### DIFF
--- a/doc-api-examples/src/main/resources/python/frame/timeseries_augmented_dickey_fuller_test.rst
+++ b/doc-api-examples/src/main/resources/python/frame/timeseries_augmented_dickey_fuller_test.rst
@@ -57,7 +57,7 @@ Calcuate the augmented Dickey-Fuller test statistic for column "b" with no lag:
 <progress>
 
 >>> result["p_value"]
-0.7317795217142998
+0.8318769494612004
 
 >>> result["test_stat"]
--1.0573441288025922
+-0.7553870527334429

--- a/pom.xml
+++ b/pom.xml
@@ -1589,7 +1589,7 @@ export MAVEN_OPTS="-Xmx512m -XX:PermSize=256m"
             <dependency>
                 <groupId>com.cloudera.sparkts</groupId>
                 <artifactId>sparkts</artifactId>
-                <version>0.3.4</version>
+                <version>0.3.5</version>
                 <exclusions>
                     <exclusion>
                         <artifactId>breeze_${scala.short.version}</artifactId>


### PR DESCRIPTION
Update pom.xml to use spark-timeseries 0.3.5, which includes a fix for the Augmented Dickey-Fuller time series test.  Updated the ADF example to reflect the fixed value.
